### PR TITLE
Added phone state intents to allow external app to monitor phone call state

### DIFF
--- a/restcomm.android.client.sdk/src/main/java/org/mobicents/restcomm/android/client/sdk/RCConnection.java
+++ b/restcomm.android.client.sdk/src/main/java/org/mobicents/restcomm/android/client/sdk/RCConnection.java
@@ -50,6 +50,7 @@
 package org.mobicents.restcomm.android.client.sdk;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.opengl.GLSurfaceView;
 import android.os.Handler;
@@ -348,6 +349,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
             }
         };
         mainHandler.post(myRunnable);
+        // Phone state Intents to capture connecting event
+        sendConnectionIntent("connecting");
     }
 
     public void onSipUAConnected(SipEvent event)
@@ -369,6 +372,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
             }
         };
         mainHandler.post(myRunnable);
+        // Phone state Intents to capture call connected event
+        sendConnectionIntent("connected");
     }
 
     public void onSipUADisconnected(final SipEvent event)
@@ -397,6 +402,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
         mainHandler.post(myRunnable);
 
         this.state = ConnectionState.DISCONNECTED;
+        // Phone state Intents to capture normal disconnect event
+        sendConnectionIntent("disconnected");
     }
 
     public void onSipUACancelled(SipEvent event)
@@ -420,6 +427,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
         mainHandler.post(myRunnable);
 
         this.state = ConnectionState.DISCONNECTED;
+        // Phone state Intents to capture cancelled event
+        sendConnectionIntent("cancelled");
     }
 
     public void onSipUADeclined(SipEvent event)
@@ -442,6 +451,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
         mainHandler.post(myRunnable);
 
         this.state = ConnectionState.DISCONNECTED;
+        // Phone state Intents to capture declined event
+        sendConnectionIntent("declined");
     }
 
     // Helpers
@@ -463,6 +474,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
             if (this.listener != null) {
                 this.listener.onDisconnected(this, RCClient.ErrorCodes.NO_CONNECTIVITY.ordinal(), RCClient.errorText(RCClient.ErrorCodes.NO_CONNECTIVITY));
             }
+            // Phone state Intents to capture dropped call due to no connectivity
+            sendDisconnectErrorIntent (RCClient.ErrorCodes.NO_CONNECTIVITY.ordinal(), RCClient.errorText(RCClient.ErrorCodes.NO_CONNECTIVITY));
             return false;
         }
     }
@@ -747,6 +760,8 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
                 if (connection.listener != null) {
                     connection.listener.onDisconnected(connection, RCClient.ErrorCodes.WEBRTC_PEERCONNECTION_ERROR.ordinal(), description);
                 }
+                // Phone state Intents to capture dropped call event
+                sendDisconnectErrorIntent(RCClient.ErrorCodes.WEBRTC_PEERCONNECTION_ERROR.ordinal(), description);
             }
         };
         mainHandler.post(myRunnable);
@@ -797,6 +812,11 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
             }
         };
         mainHandler.post(myRunnable);
+        // Phone state Intents to capture dialing or answering event
+        if (signalingParameters.initiator)
+            sendConnectionIntent("dialing");
+        else
+            sendConnectionIntent("answering");
     }
 
     private void onConnectedToRoomInternal(final SignalingParameters params) {
@@ -878,5 +898,38 @@ public class RCConnection implements SipUAConnectionListener, PeerConnectionClie
         for (IceCandidate candidate : candidates) {
             peerConnectionClient.addRemoteIceCandidate(candidate);
         }
+    }
+
+    // Phone state Intents to capture events
+    private void sendConnectionIntent (String state)
+    {
+        SignalingParameters params = this.signalingParameters;
+        Intent intent = new Intent ("org.mobicents.restcomm.android.CALL_STATE");
+        intent.putExtra("STATE", state);
+        intent.putExtra("INCOMING", this.isIncoming());
+        if (params != null)
+        {
+            intent.putExtra("VIDEO", params.videoEnabled);
+            intent.putExtra("REQUEST", params.sipUrl);
+        }
+        if (this.getState() != null)
+            intent.putExtra("CONNECTIONSTATE", this.getState().toString());
+
+        Context context = RCClient.getContext();
+        context.sendBroadcast(intent);
+    }
+
+    // Phone state Intents to capture dropped call event with reason
+    private void sendDisconnectErrorIntent (int error, String errorText)
+    {
+        Intent intent = new Intent ("org.mobicents.restcomm.android.DISCONNECT_ERROR");
+        intent.putExtra("STATE", "disconnect error");
+        if (errorText != null)
+            intent.putExtra("ERRORTEXT", errorText);
+        intent.putExtra("ERROR", error);
+        intent.putExtra("INCOMING", this.isIncoming());
+
+        Context context = RCClient.getContext();
+        context.sendBroadcast(intent);
     }
 }

--- a/restcomm.android.client.sdk/src/main/java/org/mobicents/restcomm/android/client/sdk/RCDeviceListener.java
+++ b/restcomm.android.client.sdk/src/main/java/org/mobicents/restcomm/android/client/sdk/RCDeviceListener.java
@@ -59,7 +59,7 @@ public interface RCDeviceListener {
      *  @param device     Device of interest
      *  @param connection Newly established connection
      */
-    //public abstract void onIncomingConnection(RCDevice device, RCConnection connection);
+    public abstract void onIncomingConnection(RCDevice device, RCConnection connection);
 
     /**
      * Text message received
@@ -67,7 +67,7 @@ public interface RCDeviceListener {
      * @param message  Tex message
      * @param parameters  Parameters, such as 'username' designating the username who sent the message
      */
-    //public abstract void onIncomingMessage(RCDevice device, String message, HashMap<String, String> parameters);
+    public abstract void onIncomingMessage(RCDevice device, String message, HashMap<String, String> parameters);
 
     /**
      *  Called to query whether the application wants to retrieve presence events. Return false to indicate that the application isn't interested (<b>Not implemented yet</b>)


### PR DESCRIPTION
These changes are to send Intents with some extra data whenever the Device Listener or Connection Listener is called for the following events:
connecting,connected,connect failed,dialing,incoming/ringing,answering,cancelled,declined,disconnected and disconnected with error.
This is so that an external app is able to receive those intents and monitor and report the sip calls.

The only other change was to re-enable a listener that so that the helloworld sample app could answer an incoming call. In RCDeviceListener.java I re-enabled onIncomingConnection. 