### PR TITLE
Fixes #694: Split clean uri if it contains host part and remove dash

### DIFF
--- a/restcomm.android.sdk/src/main/java/org/restcomm/android/sdk/SignalingClient/JainSipClient/JainSipMessageBuilder.java
+++ b/restcomm.android.sdk/src/main/java/org/restcomm/android/sdk/SignalingClient/JainSipClient/JainSipMessageBuilder.java
@@ -124,7 +124,19 @@ class JainSipMessageBuilder {
          else {
             // non register
             // remove spaces and dashes from the sip uri
-            String cleanUri = toSipUri.replace(" ", "").replace("-", "");
+            // NB: better to cast to SipUri?
+            String cleanUri = toSipUri.replace(" ", "");
+            //might not have host part
+            int atPos = toSipUri.indexOf("@");
+            if(atPos != -1){
+                String []cleanUriParts = cleanUri.split("@");
+                cleanUriParts[0].replace("-", "");
+                cleanUri = cleanUriParts[0] + cleanUriParts[1];
+            } else{
+                //replace dashes in numbers
+                cleanUri.replace("-", "");
+            }
+
             toAddress = jainSipAddressFactory.createAddress(cleanUri);
             requestUri = jainSipAddressFactory.createURI(cleanUri);
          }


### PR DESCRIPTION
@atsakiridis Antonis, please have a look, an alternative implementation wouldve been to construct a `SipUri`