### PR TITLE
Fix for issue 855. Android 28 Compatibility issue fixed

### DIFF
--- a/restcomm.android.sdk/build.gradle
+++ b/restcomm.android.sdk/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.6.1"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -23,12 +23,12 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     //buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 28
 
         logger.info("-- Using versionCode: " + VERSION_CODE)
         versionCode VERSION_CODE.toInteger()
@@ -103,38 +103,38 @@ repositories {
 
 dependencies {
     //compile project(':libwebrtc')
-    compile 'org.webrtc:google-webrtc:1.0.21217'
+    implementation 'org.webrtc:google-webrtc:1.0.21217'
     //compile 'org.restcomm.android:libwebrtc:1.0.0-beta5-16765@aar'
     //compile files('libs/libjingle_peerconnection_java.jar')
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     // for RCDevice FSM
-    compile 'org.squirrelframework:squirrel-foundation:0.3.8'
+    implementation 'org.squirrelframework:squirrel-foundation:0.3.8'
 //    compile 'com.googlecode:openbeans:1.0'
     // Notice that log4j 2.7 doesn't work on account of JAIN SIP expecting log4j GroupId, not org.apache.logging.log4j
     // TODO: We should try to fix that at some point
     //compile 'org.apache.logging.log4j:log4j:2.7'
     // So we 're using 1.2.17 which uses the same Group Id, and also use 1.2.17 instead of 1.2.15 which has a dependency that causes us issues
-    compile 'log4j:log4j:1.2.17'
-    compile 'javax.sip:android-jain-sip-ri:1.2.293'
+    implementation 'log4j:log4j:1.2.17'
+    implementation 'javax.sip:android-jain-sip-ri:1.2.293'
     // Provide JAIN SIP with proper Bouncy Castle encryption facilities (although Android seems to support BC, it appears that it has issues)
-    compile 'com.madgag.spongycastle:core:1.54.0.0'
-    compile 'com.madgag.spongycastle:prov:1.54.0.0'
-    compile 'com.madgag.spongycastle:pkix:1.54.0.0'
+    implementation 'com.madgag.spongycastle:core:1.58.0.0'
+    implementation 'com.madgag.spongycastle:prov:1.58.0.0'
+    implementation 'com.madgag.spongycastle:pkix:1.58.0.0'
     // Required for local unit tests (JUnit 4 framework)
     //testCompile 'junit:junit:4.12'
     // Even though sdk doesn't directly use dnsjava, we need it for android-jain-sip-ext. The reason is that for now android-jain-sip-ext declares its dependency to
     // dnsjava as 'provided', because in non android environment it is provided already (i.e. sip servlets). Until we fix the android-jain-sip-ext .pom let's leave it
     // at that
-    compile 'dnsjava:dnsjava:2.1.7'
-    compile 'org.mobicents.javax.sip:android-jain-sip-ext:1.3.33'
+    implementation 'dnsjava:dnsjava:2.1.7'
+    implementation 'org.mobicents.javax.sip:android-jain-sip-ext:1.3.33'
     //compile 'org.mobicents.javax.sip:android-jain-sip-ext:1.3.0-SNAPSHOT'
-    compile 'com.google.firebase:firebase-messaging:11.8.0'
-    compile 'com.firebase:firebase-jobdispatcher:0.6.0'
+    implementation 'com.google.firebase:firebase-messaging:11.8.0'
+    implementation 'com.firebase:firebase-jobdispatcher:0.6.0'
 
     // deps for roboelectric; remember it runs on the development machine
-    testCompile "org.assertj:assertj-core:1.7.1"
-    testCompile "org.robolectric:robolectric:3.6.1"
-    testCompile 'junit:junit:4.12'
+    testImplementation "org.assertj:assertj-core:1.7.1"
+    testImplementation "org.robolectric:robolectric:3.6.1"
+    testImplementation 'junit:junit:4.12'
 }
 
 

--- a/restcomm.android.sdk/src/main/java/org/restcomm/android/sdk/SignalingClient/JainSipClient/JainSipSecurityHelper.java
+++ b/restcomm.android.sdk/src/main/java/org/restcomm/android/sdk/SignalingClient/JainSipClient/JainSipSecurityHelper.java
@@ -84,7 +84,7 @@ public class JainSipSecurityHelper {
             ks.load(null);
 
             // Generate key pair using Elliptic Curve algorithm and Bouncy Castle provider
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "BC");
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
             kpg.initialize(new ECGenParameterSpec("secp256r1"));
             KeyPair kp = kpg.generateKeyPair();
 
@@ -182,7 +182,7 @@ public class JainSipSecurityHelper {
         certGen.addExtension(X509Extensions.SubjectAlternativeName, false, new GeneralNames(new GeneralName(GeneralName.rfc822Name, "android-sdk@cloud.restcomm.com")));
 
         // provider is Bouncy Castle
-        return certGen.generateX509Certificate(pair.getPrivate(), "BC");
+        return certGen.generateX509Certificate(pair.getPrivate());
     }
 
     public static void setProperties(Properties properties, String keystorePath, String keystorePassword, Boolean disableCertVerification) {


### PR DESCRIPTION
Fix for java.security.NoSuchAlgorithmException: The BC provider no longer provides an implementation for KeyPairGenerator.EC 